### PR TITLE
Implemented the ability to self-reference line items

### DIFF
--- a/pycashflow/model.py
+++ b/pycashflow/model.py
@@ -68,11 +68,14 @@ class Model:
         for n in range(steps):
             row = {"step": n}
 
-            for name, section in self.sections.items():
-                row[name] = section.output
+            for section in self.sections.values():
+                row[section.name] = section.output
 
-                for k, v in section.items.items():
-                    row[f"{name}_{k}"] = v
+                for name, item in section.items.items():
+                    if item.self_referencing:
+                        row[f"{section.name}_{name}"] = item(n, item)
+                    else:
+                        row[f"{section.name}_{name}"] = item(n)
 
             data.append(row)
 

--- a/pycashflow/section.py
+++ b/pycashflow/section.py
@@ -12,7 +12,7 @@ class Section:
     def __init__(self, name: str) -> None:
         self.name = name
 
-        self.items = {}
+        self.items: dict[str, LineItem] = {}
         self._section_output: Optional[LineItem] = None
 
     def __getitem__(self, key: str) -> LineItem:

--- a/pycashflow/types_.py
+++ b/pycashflow/types_.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-import typing
+from typing import TYPE_CHECKING, Union, Callable, Any
 from datetime import datetime, date
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from pycashflow.lineitem import LineItem
 
-LineItemCallableReturn = typing.Union[float, int, bool, str, None]
-LineItemCallable = typing.Callable[[int], LineItemCallableReturn]
-LineItemOperand = typing.Union["LineItem", typing.Any]
+LineItemCallableReturn = Union[float, int, bool, str, None]
+LineItemCallable = Union[
+    Callable[[int], LineItemCallableReturn],
+    Callable[[int, "LineItem"], LineItemCallableReturn],
+]
+LineItemOperand = Union["LineItem", Any]
 
-DateLike = typing.Union[str, datetime, date]
+DateLike = Union[str, datetime, date]

--- a/tests/test_self_referencing.py
+++ b/tests/test_self_referencing.py
@@ -1,0 +1,30 @@
+"""Validates that you can self-reference line items."""
+
+import pytest
+
+from pycashflow import LineItem
+
+
+def test_can_use_previous_step() -> None:
+    """Validates that you can self-reference line items."""
+    line = LineItem(lambda t, self: 0 if t == 0 else self(t - 1) + t)
+
+    assert line(0) == 0
+    assert line(1) == 1
+    assert line(2) == 3
+    assert line(3) == 6
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        lambda t, self: self(t - 1) + t,
+        lambda t, self: self(t + 1) + t,
+    ],
+)
+def test_raises_recursion_error_if_undefined(func) -> None:
+    """Validates that a recursion error is raised if the line item is poorly defined."""
+    line = LineItem(func)
+
+    with pytest.raises(RecursionError):
+        line(0)  # Will recurse infinitely


### PR DESCRIPTION
It can be useful in certain cases to be able to "self-reference". In particular, this is useful when you're building recursive models such as a MoM growth model.